### PR TITLE
fix-issue-with-function-input-number-distinction

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number) {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
There was an error in the input for the fibonacci function written in the file,  n does not have a type, resulting in an error when translating the file from typescript to javascript. The fix occurred by replacing 'n' with 'n:number' and this fix was tested by running the file with a sample input value such as 10, which then was given to the function and then the function returned 55.