### PR TITLE
fix-req-res-types

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -2,7 +2,7 @@
 
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req: any, res: any) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
fibRoute.ts file had an error when translating from typescript to javascript in which it pointed out that req and res parameters were missing a type declaration. This issue was solved by declaring both req and res to be of type 'any', allowing any input to come in and out. 