### PR TITLE
fix-return-type-of-function

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n: number) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
Adjusted return type of fibonacci function as lint and test workflow was pointing out error surronding the return line of the file. Change tested manually by running the file locally.